### PR TITLE
BugFix: Incorrect func names in derived classes

### DIFF
--- a/src/HardwareSimulatorLib/Cluster/Placement/Impl/BestFitSelector.cs
+++ b/src/HardwareSimulatorLib/Cluster/Placement/Impl/BestFitSelector.cs
@@ -10,7 +10,7 @@ namespace HardwareSimulatorLib.Cluster.Placement.Impl
             base(cluster, experimentParams, rand)
         { }
 
-        protected override void CompteNodeScores(string replicaId,
+        protected override void ComputeNodeScores(string replicaId,
             double[] nodeIdToCpuUsage, double[] nodeIdToMemoryUsage,
             double[] nodeIdToDiskUsage, double replicaCpuUsage,
             double replicaMemoryUsage, double replicaDiskUsage,

--- a/src/HardwareSimulatorLib/Cluster/Placement/Impl/DotProductSelector.cs
+++ b/src/HardwareSimulatorLib/Cluster/Placement/Impl/DotProductSelector.cs
@@ -11,7 +11,7 @@ namespace HardwareSimulatorLib.Cluster.Placement.Impl
             base(cluster, experimentParams, rand)
         { }
 
-        protected override void CompteNodeScores(string replicaId,
+        protected override void ComputeNodeScores(string replicaId,
             double[] nodeIdToCpuUsage, double[] nodeIdToMemoryUsage,
             double[] nodeIdToDiskUsage, double replicaCpuUsage,
             double replicaMemoryUsage, double replicaDiskUsage,

--- a/src/HardwareSimulatorLib/Cluster/Placement/Impl/InnerProductSelector.cs
+++ b/src/HardwareSimulatorLib/Cluster/Placement/Impl/InnerProductSelector.cs
@@ -10,7 +10,7 @@ namespace HardwareSimulatorLib.Cluster.Placement.Impl
             base(cluster, experimentParams, rand)
         { }
 
-        protected override void CompteNodeScores(string replicaId,
+        protected override void ComputeNodeScores(string replicaId,
             double[] nodeIdToCpuUsage, double[] nodeIdToMemoryUsage,
             double[] nodeIdToDiskUsage, double replicaCpuUsage,
             double replicaMemoryUsage, double replicaDiskUsage,

--- a/src/HardwareSimulatorLib/Cluster/Placement/Impl/L2NormSelector.cs
+++ b/src/HardwareSimulatorLib/Cluster/Placement/Impl/L2NormSelector.cs
@@ -10,7 +10,7 @@ namespace HardwareSimulatorLib.Cluster.Placement.Impl
             base(cluster, experimentParams, rand)
         { }
 
-        protected override void CompteNodeScores(string replicaId,
+        protected override void ComputeNodeScores(string replicaId,
             double[] nodeIdToCpuUsage, double[] nodeIdToMemoryUsage,
             double[] nodeIdToDiskUsage, double replicaCpuUsage,
             double replicaMemoryUsage, double replicaDiskUsage,

--- a/src/HardwareSimulatorLib/Cluster/Placement/Impl/MinStdDivSelector.cs
+++ b/src/HardwareSimulatorLib/Cluster/Placement/Impl/MinStdDivSelector.cs
@@ -11,7 +11,7 @@ namespace HardwareSimulatorLib.Cluster.Placement.Impl
             base(cluster, experimentParams, rand)
         { }
 
-        protected override void CompteNodeScores(string replicaId,
+        protected override void ComputeNodeScores(string replicaId,
             double[] nodeIdToCpuUsage, double[] nodeIdToMemoryUsage,
             double[] nodeIdToDiskUsage, double replicaCpuUsage,
             double replicaMemoryUsage, double replicaDiskUsage,

--- a/src/HardwareSimulatorLib/Cluster/Placement/Impl/PenaltiesSelector.cs
+++ b/src/HardwareSimulatorLib/Cluster/Placement/Impl/PenaltiesSelector.cs
@@ -16,7 +16,7 @@ namespace HardwareSimulatorLib.Cluster.Placement.Impl
             this.penaltiesParameterThreshold = experimentParams.PenaltiesParameterThreshold;
         }
 
-        protected override void CompteNodeScores(string replicaId,
+        protected override void ComputeNodeScores(string replicaId,
             double[] nodeIdToCpuUsage, double[] nodeIdToMemoryUsage,
             double[] nodeIdToDiskUsage, double replicaCpuUsage,
             double replicaMemoryUsage, double replicaDiskUsage,

--- a/src/HardwareSimulatorLib/Cluster/Placement/Impl/ProbabilityViolationBestFitSelector.cs
+++ b/src/HardwareSimulatorLib/Cluster/Placement/Impl/ProbabilityViolationBestFitSelector.cs
@@ -11,7 +11,7 @@ namespace HardwareSimulatorLib.Cluster.Placement.Impl
             base(cluster, experimentParams, rand, predictor)
         { }
 
-        protected override void CompteNodeScores(string replicaId,
+        protected override void ComputeNodeScores(string replicaId,
             double[] nodeIdToCpuUsage, double[] nodeIdToMemoryUsage,
             double[] nodeIdToDiskUsage, double replicaCpuUsage,
             double replicaMemoryUsage, double replicaDiskUsage,

--- a/src/HardwareSimulatorLib/Cluster/Placement/Impl/ProbabilityViolationWorstFitSelector.cs
+++ b/src/HardwareSimulatorLib/Cluster/Placement/Impl/ProbabilityViolationWorstFitSelector.cs
@@ -11,7 +11,7 @@ namespace HardwareSimulatorLib.Cluster.Placement.Impl
             base(cluster, experimentParams, rand, predictor)
         { }
 
-        protected override void CompteNodeScores(string replicaId,
+        protected override void ComputeNodeScores(string replicaId,
             double[] nodeIdToCpuUsage, double[] nodeIdToMemoryUsage,
             double[] nodeIdToDiskUsage, double replicaCpuUsage,
             double replicaMemoryUsage, double replicaDiskUsage,

--- a/src/HardwareSimulatorLib/Cluster/Placement/Impl/ProbabilityViolationWorstFitUpgradeSelector.cs
+++ b/src/HardwareSimulatorLib/Cluster/Placement/Impl/ProbabilityViolationWorstFitUpgradeSelector.cs
@@ -14,7 +14,7 @@ namespace HardwareSimulatorLib.Cluster.Placement.Impl
                 base(cluster, experimentParams, rand, predictor)
         { }
 
-        protected override void CompteNodeScores(string replicaId,
+        protected override void ComputeNodeScores(string replicaId,
             double[] nodeIdToCpuUsage, double[] nodeIdToMemoryUsage,
             double[] nodeIdToDiskUsage, double replicaCpuUsage,
             double replicaMemoryUsage, double replicaDiskUsage,

--- a/src/HardwareSimulatorLib/Cluster/Placement/Impl/SumOfSquaresSelector.cs
+++ b/src/HardwareSimulatorLib/Cluster/Placement/Impl/SumOfSquaresSelector.cs
@@ -11,7 +11,7 @@ namespace HardwareSimulatorLib.Cluster.Placement.Impl
             base(cluster, experimentParams, rand)
         { }
 
-        protected override void CompteNodeScores(string replicaId,
+        protected override void ComputeNodeScores(string replicaId,
             double[] nodeIdToCpuUsage, double[] nodeIdToMemoryUsage,
             double[] nodeIdToDiskUsage, double replicaCpuUsage,
             double replicaMemoryUsage, double replicaDiskUsage,

--- a/src/HardwareSimulatorLib/Cluster/Placement/Impl/WorstFitSelector.cs
+++ b/src/HardwareSimulatorLib/Cluster/Placement/Impl/WorstFitSelector.cs
@@ -10,7 +10,7 @@ namespace HardwareSimulatorLib.Cluster.Placement.Impl
             base(clusterManager, experimentParams, rand)
         { }
 
-        protected override void CompteNodeScores(string replicaId,
+        protected override void ComputeNodeScores(string replicaId,
             double[] nodeIdToCpuUsage, double[] nodeIdToMemoryUsage,
             double[] nodeIdToDiskUsage, double replicaCpuUsage,
             double replicaMemoryUsage, double replicaDiskUsage,

--- a/src/HardwareSimulatorLib/Cluster/Placement/Impl/WorstFitUpgradeSelector.cs
+++ b/src/HardwareSimulatorLib/Cluster/Placement/Impl/WorstFitUpgradeSelector.cs
@@ -11,7 +11,7 @@ namespace HardwareSimulatorLib.Cluster.Placement.Impl
             base(clusterManager, experimentParams, rand)
         { }
 
-        protected override void CompteNodeScores(string replicaId,
+        protected override void ComputeNodeScores(string replicaId,
             double[] nodeIdToCpuUsage, double[] nodeIdToMemoryUsage,
             double[] nodeIdToDiskUsage, double replicaCpuUsage,
             double replicaMemoryUsage, double replicaDiskUsage,


### PR DESCRIPTION
Method 'ComputeNodeScores' was renamed in PlacementSelector but not its derived classes.