### PR TITLE
No placement on heavily used nodes

### DIFF
--- a/src/HardwareSimulatorLib/Cluster/ClusterManager.cs
+++ b/src/HardwareSimulatorLib/Cluster/ClusterManager.cs
@@ -23,6 +23,8 @@ namespace HardwareSimulatorLib.Cluster
         public double NodeNumCores;
         public double NodeMemorySizeInMB;
         public double NodeDiskSizeInMB;
+        public double NodeMemUsageLimitForPlacement;
+        public double NodeDiskUsageLimitForPlacement;
 
         // nodes IDs are 0 to NumNodes - 1
         public readonly int NumNodes;
@@ -90,6 +92,8 @@ namespace HardwareSimulatorLib.Cluster
             NodeNumCores = Params.NodeNumCores;
             NodeMemorySizeInMB = Params.NodeMemorySizeInMB;
             NodeDiskSizeInMB = Params.NodeDiskSizeInMB;
+            NodeMemUsageLimitForPlacement = Params.NodeMemUsageLimitForPlacement;
+            NodeDiskUsageLimitForPlacement = Params.NodeDiskUsageLimitForPlacement;
 
             NodeIdToCurrCpuUsage = new double[NumNodes];
             NodeIdToCurrDiskUsage = new double[NumNodes];

--- a/src/HardwareSimulatorLib/Cluster/Placement/Impl/WorstFitUpgradeSelector.cs
+++ b/src/HardwareSimulatorLib/Cluster/Placement/Impl/WorstFitUpgradeSelector.cs
@@ -35,8 +35,8 @@ namespace HardwareSimulatorLib.Cluster.Placement.Impl
 
                 // Check if node can accomodate the new tenant's resource usage
                 if (excludedNodeIds.Contains(nodeId) ||
-                    nodeIdToDiskUsage[nodeId] + replicaDiskUsage > cluster.NodeDiskSizeInMB ||
-                    nodeIdToMemoryUsage[nodeId] + replicaMemoryUsage > cluster.NodeMemorySizeInMB ||
+                    nodeIdToDiskUsage[nodeId] + replicaDiskUsage > cluster.NodeDiskUsageLimitForPlacement ||
+                    nodeIdToMemoryUsage[nodeId] + replicaMemoryUsage > cluster.NodeMemUsageLimitForPlacement ||
                     nodeIdToCpuUsage[nodeId] + replicaCpuUsage > cluster.NodeNumCores * 10000 ||
                     nodeId == srcNodeId)
                 {

--- a/src/HardwareSimulatorLib/Config/SearchSpace.cs
+++ b/src/HardwareSimulatorLib/Config/SearchSpace.cs
@@ -26,5 +26,7 @@
         public double[] DiskCaps = { 1.0, 0.70, 0.75, 0.8 };
         public double[] MemoryCaps = { 0.9, 0.85 };
         public double[] CpuCaps = { 0.9 };
+        public double[] NodeMemMaxUsageRatiosForPlacement = { 0.9 };
+        public double[] NodeDiskMaxUsageRatiosForPlacement = { 0.9 };
     }
 }

--- a/src/HardwareSimulatorLib/Config/SimulationConfiguration.cs
+++ b/src/HardwareSimulatorLib/Config/SimulationConfiguration.cs
@@ -40,6 +40,8 @@ namespace HardwareSimulatorLib.Config
                    SearchSpace.DiskSizesInGB.Length *
                    SearchSpace.MemorySizesInGB.Length *
                    SearchSpace.OverbookingRatios.Length *
+                   SearchSpace.NodeMemMaxUsageRatiosForPlacement.Length * 
+                   SearchSpace.NodeDiskMaxUsageRatiosForPlacement.Length * 
                    PlacementAlgorithm.PlacementHeuristic.Length;
         }
 
@@ -50,7 +52,9 @@ namespace HardwareSimulatorLib.Config
                    SearchSpace.VCoresPerNode.Length *
                    SearchSpace.DiskSizesInGB.Length *
                    SearchSpace.MemorySizesInGB.Length *
-                   SearchSpace.OverbookingRatios.Length;
+                   SearchSpace.OverbookingRatios.Length *
+                   SearchSpace.NodeMemMaxUsageRatiosForPlacement.Length * 
+                   SearchSpace.NodeDiskMaxUsageRatiosForPlacement.Length;
         }
 
         public IEnumerable<ExperimentParams> GetAllExperimentsParams()
@@ -63,6 +67,8 @@ namespace HardwareSimulatorLib.Config
             foreach (var memorySizeInGB in SearchSpace.MemorySizesInGB)
             foreach (var diskSizeInGB in SearchSpace.DiskSizesInGB)
             foreach (var overbookingRatio in SearchSpace.OverbookingRatios)
+            foreach (var nodeMemMaxUsageRatioForPlacement in SearchSpace.NodeMemMaxUsageRatiosForPlacement)
+            foreach (var nodeDiskMaxUsageRatioForPlacement in SearchSpace.NodeDiskMaxUsageRatiosForPlacement)
             /* We fix values over the search space then loop over the set of
              * possible experiments based on the 'PlacementAlgorithm' */
             {
@@ -89,6 +95,12 @@ namespace HardwareSimulatorLib.Config
                             ClusterConfiguration.MemoryOverheadPerNodeInGB),
                         NodeDiskSizeInMB   = 1024 * (diskSizeInGB -
                             ClusterConfiguration.DiskOverheadPerNodeInGB),
+                        NodeMemUsageLimitForPlacement = 1024 * (memorySizeInGB -
+                            ClusterConfiguration.MemoryOverheadPerNodeInGB) * 
+                            nodeMemMaxUsageRatioForPlacement,
+                        NodeDiskUsageLimitForPlacement = 1024 * (diskSizeInGB -
+                            ClusterConfiguration.DiskOverheadPerNodeInGB) *
+                            nodeDiskMaxUsageRatioForPlacement,
 
                         // Second, set base experiment params.
                         NumNodes = ClusterConfiguration.Nodes,

--- a/src/HardwareSimulatorLib/Experiment/ExperimentParams.cs
+++ b/src/HardwareSimulatorLib/Experiment/ExperimentParams.cs
@@ -13,6 +13,8 @@ namespace HardwareSimulatorLib.Experiment
         public double NodeDiskSizeInMB;
         public double NodeMemorySizeInMB;
         public double OverbookingRatio;
+        public double NodeMemUsageLimitForPlacement;
+        public double NodeDiskUsageLimitForPlacement;
 
         public int NumNodes;
         public string HardwareGeneration;


### PR DESCRIPTION
Following up on a previous discussion, new params are introduced to avoid placing replicas on heavily used nodes disregarding upgrade moves.